### PR TITLE
fix bug with unicode char in urls

### DIFF
--- a/uddup/main.py
+++ b/uddup/main.py
@@ -180,7 +180,7 @@ def main(urls_file, output, silent, filter_path):
     web_suffixes = get_web_suffixes()
     ignored_suffixes = get_ignored_suffixes()
     # Iterate over the given domains
-    with open(urls_file, 'r') as f:
+    with open(urls_file, 'r', encoding="utf-8") as f:
         for url in f:
             url = url.rstrip()
             if not url:


### PR DESCRIPTION
This fixes a problem with URLs with UTF8 chars, e.g: 

```
echo "http://www.shakedos.com:80/index.php/2010/05/עבודה-עם-שפות-ללא-טבלאות-מוכנות/feed/" > /tmp/urls.txt
uddup -u /tmp/urls.txt 
...
Traceback (most recent call last):
  File "/usr/local/bin/uddup", line 11, in <module>
    sys.exit(interactive())
  File "/usr/local/lib/python3.5/dist-packages/uddup/main.py", line 269, in interactive
    main(args.urls_file, args.output, args.silent, args.filter_path)
  File "/usr/local/lib/python3.5/dist-packages/uddup/main.py", line 184, in main
    for url in f:
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd7 in position 100: ordinal not in range(128
```

