### PR TITLE
Fix query param parsing and banner warning

### DIFF
--- a/uddup/main.py
+++ b/uddup/main.py
@@ -28,13 +28,13 @@ else:
 
 
 def banner():
-    print("""%s
-  _   _ ____      _             
- | | | |  _ \  __| |_   _ _ __  
- | | | | | | |/ _` | | | | '_ \ 
+    print(r"""%s
+  _   _ ____      _
+ | | | |  _ \  __| |_   _ _ __
+ | | | | | | |/ _` | | | | '_ \
  | |_| | |_| | (_| | |_| | |_) |
-  \___/|____/ \__,_|\__,_| .__/ 
-                         |_|    
+  \___/|____/ \__,_|\__,_| .__/
+                         |_|
 
               %s# Coded By @2RS3C
     %s""" % (Y, G, W))
@@ -141,6 +141,9 @@ def get_existing_pattern_urls(purl, uurls):
 
 
 def get_query_params_keys(parsed_url_query):
+    if not parsed_url_query:
+        return []
+
     keys = []
     qparams = parsed_url_query.split('&')
     for q in qparams:


### PR DESCRIPTION
## Summary
- fix banner string warning by using a raw string
- handle empty querystrings correctly in `get_query_params_keys`

## Testing
- `pytest -q`